### PR TITLE
Remove `types` field from TSConfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
     "jsx": "preserve",
     "incremental": true,
     "useDefineForClassFields": true,
-    "types": ["reflect-metadata"],
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true
   },


### PR DESCRIPTION
This fixes the setup script, avoids having to import type dependencies, and simplifies the config.

Fixes #3.